### PR TITLE
use Option component for showing list of options

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -21,9 +21,9 @@ const styles = StyleSheet.create({
     position: 'absolute',
     borderColor: '#BDBDC1',
     borderWidth: 2 / window.scale,
-    borderTopColor: 'transparent',
+    borderTopColor: 'transparent'
   }
-})
+});
 
 class Items extends Component {
   constructor(props) {
@@ -38,13 +38,8 @@ class Items extends Component {
     }
 
     const renderedItems = React.Children.map(items, (item) => {
-
       return (
-        <TouchableWithoutFeedback onPress={() => onPress(item.props.children, item.props.value) }>
-          <View>
-            {item}
-          </View>
-        </TouchableWithoutFeedback>
+        React.cloneElement(item, {onPress: () => onPress(item.props.children, item.props.value)})
       );
     });
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -4,6 +4,7 @@ const {
   StyleSheet,
   Component,
   View,
+  TouchableWithoutFeedback,
   Text
 } = React;
 
@@ -19,12 +20,14 @@ class Option extends Component {
   }
 
   render() {
-    const { style, styleText } = this.props;
+    const { style, styleText, onPress } = this.props;
 
     return (
-      <View style={[ styles.container, style ]}>
-        <Text style={ styleText }>{this.props.children}</Text>
-      </View>
+      <TouchableWithoutFeedback onPress={onPress}>
+        <View style={[ styles.container, style ]}>
+          <Text style={ styleText }>{this.props.children}</Text>
+        </View>
+      </TouchableWithoutFeedback>
     );
   }
 }

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -35,7 +35,7 @@ class Overlay extends Component {
     const { pageX, pageY, show, onPress } = this.props;
 
     if (!show) {
-      return null
+      return null;
     }
 
     return (

--- a/lib/select.js
+++ b/lib/select.js
@@ -5,7 +5,6 @@ const {
   Dimensions,
   StyleSheet,
   Component,
-  TouchableWithoutFeedback,
   View
 } = React;
 
@@ -39,7 +38,7 @@ class Select extends Component {
 
     this.state = {
       value: defaultValue
-    }
+    };
   }
 
   reset() {
@@ -74,11 +73,9 @@ class Select extends Component {
     const dimensions = { width, height };
 
     return (
-      <TouchableWithoutFeedback onPress={this._onPress.bind(this)}>
-        <View ref={SELECT} style={[styles.container, style, dimensions ]}>
-          <Option style={ styleOption } styleText={ styleText }>{this.state.value}</Option>
-        </View>
-      </TouchableWithoutFeedback>
+      <View ref={SELECT} style={[styles.container, style, dimensions ]}>
+        <Option onPress={this._onPress.bind(this)} style={ styleOption } styleText={ styleText }>{this.state.value}</Option>
+      </View>
     );
   }
 }


### PR DESCRIPTION
currently Option component is used just for rendering default/selected dropdown value. For rendering values when dropdown opens, new custom component is used, which is the reason why `<Option styleText={{color: '#FFF'}}>Manitoba</Option>` does not work. I changed this, so Option component is rendered for every option in dropdown list. This allows us to pass custom styling for options in dropdown list.
