### PR TITLE
Add background color to Item Dropdown to '#fff', now it's transparent

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -22,6 +22,7 @@ const styles = StyleSheet.create({
     borderColor: '#BDBDC1',
     borderWidth: 2 / window.scale,
     borderTopColor: 'transparent',
+    backgroundColor : '#ffffff'
   }
 })
 


### PR DESCRIPTION
In the items.js file, I put one line that can be force the background to "#fff", now it's transparent which is not very good when there is stacked component. 
