### PR TITLE
Fixed android and added new props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,11 @@
-const Option = require('./option');
-const OptionList = require('./optionList');
-const Select = require('./select');
-const updatePosition = require('./updatePosition');
+import Option from './option'
+import OptionList from './optionList'
+import Select from './select'
+import updatePosition from './updatePosition'
 
-
-module.exports = {
-  Option,
-  OptionList,
-  Select,
-  updatePosition
-};
+export {
+	Option,
+	OptionList,
+	Select,
+	updatePosition
+}

--- a/lib/items.js
+++ b/lib/items.js
@@ -1,14 +1,6 @@
-const React = require('react-native');
-
-const {
-  Dimensions,
-  StyleSheet,
-  Component,
-  View,
-  ScrollView,
-  TouchableWithoutFeedback,
-  Text
-} = React;
+import React, { Component, } from 'react';
+import { Dimensions, StyleSheet, View, ScrollView, TouchableWithoutFeedback, Text } from 'react-native'
+import PropTypes from 'prop-types'
 
 const window = Dimensions.get('window');
 
@@ -22,23 +14,18 @@ const styles = StyleSheet.create({
     borderColor: '#BDBDC1',
     borderWidth: 2 / window.scale,
     borderTopColor: 'transparent',
+    backgroundColor: 'white'
   }
 })
 
-class Items extends Component {
+export default class Items extends Component {
   constructor(props) {
     super(props);
   }
 
   render() {
-    const { items, positionX, positionY, show, onPress, width, height } = this.props;
-
-    if (!show) {
-      return null;
-    }
-
+    const { items, positionX, positionY, show, onPress, width, height, children, customScrollViewComp, autoHeightItemsList } = this.props;
     const renderedItems = React.Children.map(items, (item) => {
-
       return (
         <TouchableWithoutFeedback onPress={() => onPress(item.props.children, item.props.value) }>
           <View>
@@ -47,25 +34,28 @@ class Items extends Component {
         </TouchableWithoutFeedback>
       );
     });
-
+    const ScrollViewComp = customScrollViewComp
+      ? customScrollViewComp
+      : ScrollView
     return (
       <View style={[styles.container, { top: positionY, left: positionX }]}>
-        <ScrollView
-          style={{ width: width - 2, height: height * 3 }}
+        <ScrollViewComp
+          style={{ width: width - 2, height: autoHeightItemsList && items.length < 3 ? 'auto' : height * 3 }}
           automaticallyAdjustContentInsets={false}
           bounces={false}>
           {renderedItems}
-        </ScrollView>
+        </ScrollViewComp>
       </View>
     );
   }
 }
 
 Items.propTypes = {
-  positionX: React.PropTypes.number,
-  positionY: React.PropTypes.number,
-  show: React.PropTypes.bool,
-  onPress: React.PropTypes.func
+  positionX: PropTypes.number,
+  positionY: PropTypes.number,
+  show: PropTypes.bool,
+  onPress: PropTypes.func,
+  autoHeightItemsList: PropTypes.bool
 };
 
 Items.defaultProps = {
@@ -74,7 +64,7 @@ Items.defaultProps = {
   positionX: 0,
   positionY: 0,
   show: false,
-  onPress: () => {}
+  onPress: () => {},
+  autoHeightItemsList: false
 };
 
-module.exports = Items;

--- a/lib/option.js
+++ b/lib/option.js
@@ -1,19 +1,17 @@
-const React = require('react-native');
+import React, { Component, } from 'react';
+import PropTypes from 'prop-types'
+import { StyleSheet, View, Text } from 'react-native'
 
-const {
-  StyleSheet,
-  Component,
-  View,
-  Text
-} = React;
+
 
 const styles = StyleSheet.create({
   container: {
-    padding: 10
+    padding: 10,
+    backgroundColor: 'white',
   }
 });
 
-class Option extends Component {
+export default class Option extends Component {
   constructor(props) {
     super(props);
   }
@@ -30,7 +28,6 @@ class Option extends Component {
 }
 
 Option.propTypes = {
-  children: React.PropTypes.string.isRequired
+  children: PropTypes.string.isRequired
 };
 
-module.exports = Option;

--- a/lib/option.js
+++ b/lib/option.js
@@ -2,8 +2,6 @@ import React, { Component, } from 'react';
 import PropTypes from 'prop-types'
 import { StyleSheet, View, Text } from 'react-native'
 
-
-
 const styles = StyleSheet.create({
   container: {
     padding: 10,

--- a/lib/optionList.js
+++ b/lib/optionList.js
@@ -1,32 +1,34 @@
-const React = require('react-native');
-const Overlay = require('./overlay');
-const Items = require('./items');
+import React, { Component, } from 'react';
+import { StyleSheet, View, Text, Dimensions } from 'react-native';
 
-const {
-  Dimensions,
-  StyleSheet,
-  Component,
-  View
-} = React;
+import Items from './items'
+import Overlay from './overlay'
 
 const window = Dimensions.get('window');
 
-class OptionList extends Component {
+const styles = StyleSheet.create({
+  wrapper: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    height: '100%',
+    width: window.width
+  }
+});
+
+export default class OptionList extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
       show: false,
-
       width: 0,
       height: 0,
-
       pageX: 0,
       pageY: 0,
-
       positionX: 0,
       positionY: 0,
-
       items: [],
       onSelect: () => { }
     };
@@ -40,7 +42,7 @@ class OptionList extends Component {
     });
   }
 
-  _show(items, positionX, positionY, width, height, onSelect) {
+  _show(items, positionX, positionY, width, height, onSelect, optionListProps) {
     positionX = positionX - this.state.pageX;
     positionY = positionY - this.state.pageY;
 
@@ -52,6 +54,7 @@ class OptionList extends Component {
       height,
       items,
       onSelect,
+      optionListProps,
       show: true
     });
   }
@@ -77,6 +80,7 @@ class OptionList extends Component {
   }
 
   render() {
+    const { customScrollViewComp } = this.props
     const {
       items,
       pageX,
@@ -85,35 +89,31 @@ class OptionList extends Component {
       positionY,
       width,
       height,
-      show
+      show,
+      optionListProps
     } = this.state;
 
+    if (!show) return null
     return (
-      <View>
+      <View style={styles.wrapper}>
         <Overlay
           pageX={pageX}
           pageY={pageY}
           show={show}
           onPress={ this._onOverlayPress.bind(this) }/>
         <Items
+          autoHeightItemsList={optionListProps && optionListProps.autoHeightItemsList}
           items={items}
           positionX={positionX}
           positionY={positionY}
           width={width}
           height={height}
           show={show}
+          customScrollViewComp={customScrollViewComp}
           onPress={ this._onItemPress.bind(this) }/>
       </View>
     );
   }
 }
 
-OptionList.propTypes = {
 
-};
-
-OptionList.defaultProps = {
-
-};
-
-module.exports = OptionList;

--- a/lib/optionList.js
+++ b/lib/optionList.js
@@ -81,17 +81,7 @@ export default class OptionList extends Component {
 
   render() {
     const { customScrollViewComp } = this.props
-    const {
-      items,
-      pageX,
-      pageY,
-      positionX,
-      positionY,
-      width,
-      height,
-      show,
-      optionListProps
-    } = this.state;
+    const { items, pageX, pageY, positionX, positionY, width, height, show, optionListProps } = this.state;
 
     if (!show) return null
     return (

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -29,6 +29,7 @@ export default class Overlay extends Component {
 
   render() {
     const { pageX, pageY, show, onPress } = this.props;
+    
     return (
       <TouchableWithoutFeedback style={styles.container} onPress={onPress}>
         <View style={[styles.overlay, { top: -pageY, left: -pageX, height: '100%' }]}/>

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -1,12 +1,6 @@
-const React = require('react-native');
-
-const {
-  Dimensions,
-  StyleSheet,
-  Component,
-  TouchableWithoutFeedback,
-  View
-} = React;
+import React, { Component, } from 'react';
+import PropTypes from 'prop-types'
+import { Dimensions, StyleSheet, View, ScrollView, TouchableWithoutFeedback, Text } from 'react-native';
 
 const window = Dimensions.get('window');
 
@@ -16,40 +10,37 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    bottom: 0
+    bottom: 0,
+    height: '100%',
+    width: '100%'
   },
   overlay: {
     position: 'absolute',
     backgroundColor: 'transparent',
     width: window.width,
-    height: window.height
+    height: '100%'
   }
 });
 
-class Overlay extends Component {
+export default class Overlay extends Component {
   constructor(props) {
     super(props);
   }
 
   render() {
     const { pageX, pageY, show, onPress } = this.props;
-
-    if (!show) {
-      return null
-    }
-
     return (
       <TouchableWithoutFeedback style={styles.container} onPress={onPress}>
-        <View style={[styles.overlay, { top: -pageY, left: -pageX }]}/>
+        <View style={[styles.overlay, { top: -pageY, left: -pageX, height: '100%' }]}/>
       </TouchableWithoutFeedback>
     );
   }
 }
 
 Overlay.propTypes = {
-  pageX: React.PropTypes.number,
-  pageY: React.PropTypes.number,
-  show: React.PropTypes.bool
+  pageX: PropTypes.number,
+  pageY: PropTypes.number,
+  show: PropTypes.bool
 };
 
 Overlay.defaultProps = {
@@ -58,4 +49,3 @@ Overlay.defaultProps = {
   show: false
 };
 
-module.exports = Overlay;

--- a/lib/select.js
+++ b/lib/select.js
@@ -119,6 +119,7 @@ export default class Select extends Component {
   render() {
     const { width, height, children, defaultValue, style, styleOption, styleText, placeholder } = this.props;
     const dimensions = { width, height };
+  
     return (
       <TouchableWithoutFeedback onPress={this._onPress.bind(this)}>
         <View ref={SELECT} style={[styles.container, style, dimensions, {height: '100%'} ]}>

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,13 +1,8 @@
-const React = require('react-native');
-const Option = require('./option');
+import React, { Component, } from 'react';
+import { Dimensions, StyleSheet, View, ScrollView, TouchableWithoutFeedback, Text } from 'react-native';
+import PropTypes from 'prop-types'
 
-const {
-  Dimensions,
-  StyleSheet,
-  Component,
-  TouchableWithoutFeedback,
-  View
-} = React;
+import Option from './option'
 
 const window = Dimensions.get('window');
 
@@ -20,63 +15,114 @@ const styles = StyleSheet.create({
   }
 });
 
-class Select extends Component {
+export default class Select extends Component {
   constructor(props) {
     super(props);
 
     this.pageX = 0;
     this.pageY = 0;
 
-    let defaultValue = props.defaultValue;
-
-    if (!defaultValue) {
-      if (Array.isArray(props.children)) {
-        defaultValue = props.children[0].props.children;
-      } else {
-        defaultValue = props.children.props.children;
-      }
-    }
+    let defaultValue = props.defaultValue || this.getDefaultValue();
 
     this.state = {
-      value: defaultValue
+      defaultValue: defaultValue,
+      value: props.placeholder 
+        ? props.value
+        : defaultValue,
+      placeholder: props.placeholder
+    }
+  }
+
+  getDefaultValue = () => {
+    const { children } = this.props
+    if (Array.isArray(children) ) {
+      if (children[0]) {
+        return children[0].props.children;
+      } else {
+        return ''
+      }
+    } else {
+      return children.props.children;
+    }
+  }
+
+  checkCildrenProps = (props, nextProps) => {
+    if (props.children != nextProps.children) {
+      if (nextProps.children && nextProps.children.length) {
+        const childrenArray = React.Children.toArray(nextProps.children)
+        const findValueInData = childrenArray && childrenArray.find(child => child.props && child.props.children == this.state.value)
+        if (!findValueInData) this.setState({
+          value: nextProps.placeholder
+            ? ''
+            : this.state.defaultValue
+        })
+      } else {
+        this.setState({
+          value:
+            nextProps.placeholder
+              ? this.state.value
+              : this.state.defaultValue
+        })
+      }
+    }
+  }
+  
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value != nextProps.value) {
+
+      this.setState({
+        value: nextProps.value != undefined
+          ? nextProps.value
+          : nextProps.placeholder
+            ? ''
+            : this.state.defaultValue
+      }, () => this.checkCildrenProps(this.props, nextProps))
+    } else {
+      this.checkCildrenProps(this.props, nextProps)
     }
   }
 
   reset() {
-    const { defaultValue } = this.props;
-    this.setState({ value: defaultValue });
-  }
-
-  _currentPosition(pageX, pageY) {
-    this.pageX = pageX;
-    this.pageY = pageY + this.props.height;
-  }
-
-  _onPress() {
-    const { optionListRef, children, onSelect, width, height } = this.props;
-
-    if (!children.length) {
-      return false;
-    }
-
-    optionListRef()._show(children, this.pageX, this.pageY, width, height, (item, value=item) => {
-      if (item) {
-        onSelect(value);
-        this.setState({
-          value: item
-        });
-      }
+    const { placeholder } = this.props;
+    this.setState({
+      value: props.placeholder 
+        ? ''
+        : this.state.defaultValue
     });
   }
 
-  render() {
-    const { width, height, children, defaultValue, style, styleOption, styleText } = this.props;
-    const dimensions = { width, height };
+  _currentPosition(pageX, pageY) {
+    const { height } = this.props
+    this.pageX = pageX;
+    this.pageY = pageY + height;
+  }
 
+  show() {
+    this._onPress()
+  }
+
+  _onPress() {
+    const { optionListRef, children, onSelect, width, height, optionListExtraWidth, optionListLeftOffset, optionListTopOffset, optionListProps } = this.props;
+    const { topOffset = 0, leftOffset = 0, extraWidth = 0 } = optionListProps
+    if (!(children && children.length)) {
+      return false;
+    }
+    optionListRef()._show(children, this.pageX + leftOffset, this.pageY + topOffset, width + extraWidth, height, (item, value=item) => {
+      if (item) {
+        this.setState({
+          value: item
+        }, () => onSelect(value));
+      }
+    }, optionListProps);
+  }
+
+  render() {
+    const { width, height, children, defaultValue, style, styleOption, styleText, placeholder } = this.props;
+    const dimensions = { width, height };
     return (
       <TouchableWithoutFeedback onPress={this._onPress.bind(this)}>
-        <View ref={SELECT} style={[styles.container, style, dimensions ]}>
-          <Option style={ styleOption } styleText={ styleText }>{this.state.value}</Option>
+        <View ref={SELECT} style={[styles.container, style, dimensions, {height: '100%'} ]}>
+          <Option style={styleOption} styleText={styleText} >{this.state.value || placeholder}</Option>
         </View>
       </TouchableWithoutFeedback>
     );
@@ -84,16 +130,17 @@ class Select extends Component {
 }
 
 Select.propTypes = {
-  width: React.PropTypes.number,
-  height: React.PropTypes.number,
-  optionListRef: React.PropTypes.func.isRequired,
-  onSelect: React.PropTypes.func
+  width: PropTypes.number,
+  height: PropTypes.number,
+  optionListRef: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
+  optionListProps: PropTypes.object
 };
 
 Select.defaultProps = {
   width: 200,
   height: 40,
-  onSelect: () => { }
+  onSelect: () => { },
+  optionListProps: {}
 };
 
-module.exports = Select;

--- a/lib/updatePosition.js
+++ b/lib/updatePosition.js
@@ -5,12 +5,12 @@ module.exports = function (ref, debug) {
   const handle = ReactNative.findNodeHandle(ref);
   if (handle) {
   	setTimeout(() => {
-    UIManager.measure(handle, (x, y, width, height, pageX, pageY) => {
-      if (debug) {
-        console.log(x, y, width, height, pageX, pageY);
-      }
-      ref._currentPosition(pageX, pageY);
-    });
-  }, 0);
+      UIManager.measure(handle, (x, y, width, height, pageX, pageY) => {
+        if (debug) {
+          console.log(x, y, width, height, pageX, pageY);
+        }
+        ref._currentPosition(pageX, pageY);
+      });
+    }, 0);
   }
 };

--- a/lib/updatePosition.js
+++ b/lib/updatePosition.js
@@ -1,14 +1,10 @@
-const React = require('react-native');
-
-const {
-  NativeModules: {
-    UIManager
-  }
-} = React;
+import ReactNative, { NativeModules } from 'react-native'
+const { UIManager } = NativeModules;
 
 module.exports = function (ref, debug) {
-  const handle = React.findNodeHandle(ref);
-  setTimeout(() => {
+  const handle = ReactNative.findNodeHandle(ref);
+  if (handle) {
+  	setTimeout(() => {
     UIManager.measure(handle, (x, y, width, height, pageX, pageY) => {
       if (debug) {
         console.log(x, y, width, height, pageX, pageY);
@@ -16,4 +12,5 @@ module.exports = function (ref, debug) {
       ref._currentPosition(pageX, pageY);
     });
   }, 0);
+  }
 };


### PR DESCRIPTION
Fixed android. And added new props.
If you use this dropdown in ScrollView the scroll in dropdown will freeze. To get full working module on android with ScrollView you should use NestedScrollView (https://github.com/cesardeazevedo/react-native-nested-scroll-view)
and pass this scroll component by customScrollViewComp prop to Select component and also you need to change ScrollView in your app to NestedScrollView.
Example:

```jsx
<NestedScrollView>
    <Select
       width={60}
       ref="SELECT_NUMBER"
       optionListProps={{
           autoHeightItemsList: true,
           topOffset: -110,
           leftOffset: -2,
           extraWidth: 14
       }}
       optionListRef={() => this.getOptionList('OPTIONLIST_NUMBER')}
       value={this.state.number}
       placeholder="Choose number"
       style={styles.select}
       styleOption={styles.optionInSelect}
       onSelect={(value) => this.setState({number: value})}>
         <Option>1</Option>
         <Option>2</Option>
         <Option>3</Option>
    </Select>
    <OptionList customScrollViewComp={NestedScrollView} ref="OPTIONLIST_NUMBER"/>
</NestedScrollView>
```

Also the new props were added: placeholder and value. Now it works more in react way. Specify the value of the select Component by value prop (better react way than it was). 
Added placeholder prop.
Also optionListProps were added it consist of topOffset, leftOffset, extraWidth - in order if you need to move dropdown list a bit. and autoHeightItemsList - if true and there are less than three items it the height of the dropdown will automatically resize so there will be less white space.