### PR TITLE
Fixed wrong PropType for children prop

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -26,6 +26,6 @@ export default class Option extends Component {
 }
 
 Option.propTypes = {
-  children: PropTypes.string.isRequired
+  children: PropTypes.node.isRequired
 };
 


### PR DESCRIPTION
While using your library constantly get a warning about wrong type.
Please add this fix to repo.
Thank you.